### PR TITLE
Striker Fix

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -225,10 +225,11 @@
 		"uniqueTo":"VividVale",
 		"requiredTech":"Bronze Working",
 		"obsoleteTech":"Civil Service",
-		"cost":56,
+		"cost":75,
                 "movement":3,
 		"strength":11,
 		"upgradesTo":"Pikeman",
-		"uniques":["[+50]% Strength <vs [Mounted] units>", "[1] Movement point to disembark"]
+		"uniques":["[+50]% Strength <vs [Mounted] units>"],
+                "promotions": ["Charge"]
 	},
 ]


### PR DESCRIPTION
I increased the Production cost since a unit with 3 movement points and charge this early in the game is OP.
Otherwise I would suggest to remove the bonus against Mounted units