### PR TITLE
Katorga Balance

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -159,10 +159,11 @@
 		"uniqueTo":"Aleksandria",
 		"cost":100,
 		"maintenance": 1,
+		"production": 1,
 		"hurryCostModifier": 25,
 		"requiredNearbyImprovedResources": ["Copper", "Coal", "Aluminum"],
 		"requiredTech": "Metal Casting",
-		"uniques": ["Must be next to [Tundra]", "[-5]% tile improvement construction time", "[+2 Production] [in all cities]",
+		"uniques": ["Must be next to [Tundra]", "[-5]% tile improvement construction time", "[+1 Production] [in all cities]",
 			    "[+10]% [Production] [in this city] <when below [0] Happiness>"]
 	},
 	//Ketonia


### PR DESCRIPTION
I reverted katorga's bonuses back to the previous one. +2 Production in all cities by just a cheap building is amost OP.