### PR TITLE
Fixing Moniyans name and leader name not working

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -962,8 +962,8 @@
     "cities": ["Core", "Anihillation", "Hive", "Doom", "Moscow", "Infestation", "Complex 001"]
 	}
 {
-		"Name": "Moniyan",
-		"LeaderName": "Juragan I",
+		"name": "Moniyan",
+		"leaderName": "Juragan I",
                 "startBias": ["Desert"]
                 "preferredVictoryType": "Domination",
                 "startIntroPart1": "It's you! Welcome back To Moniyan Juragan! Your Country is So Big and Strong and Cover ⅔ Middle East Lands! Well... Only 500 Years we Conquered... But Empire Is Rising and Falling Right?",


### PR DESCRIPTION
Originally, the name and leader name wouldn't show up because they were accidentally capitalised.