### PR TITLE
Update UnitTypes.json

### DIFF
--- a/jsons/UnitTypes.json
+++ b/jsons/UnitTypes.json
@@ -5,41 +5,51 @@
     },
     {
         "name": "Sword",
-        "movementType": "Land"
+        "movementType": "Land",
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Gunpowder",
-        "movementType": "Land"
+        "movementType": "Land",
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Archery",
         "movementType": "Land",
-		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit>",
-					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit>"]
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Ranged Gunpowder",
         "movementType": "Land",
-		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit>",
-					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit>"]
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Scout",
-        "movementType": "Land"
+        "movementType": "Land",
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Mounted",
-        "movementType": "Land"
+        "movementType": "Land",
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Armored",
-        "movementType": "Land"
+        "movementType": "Land",
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Siege",
         "movementType": "Land",
-		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit>",
-					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit>"]
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Civilian Water",
@@ -47,11 +57,15 @@
     },
     {
         "name": "Melee Water",
-        "movementType": "Water"
+        "movementType": "Water",
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Ranged Water",
-        "movementType": "Water"
+        "movementType": "Water",
+		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
     {
         "name": "Submarine",
@@ -85,7 +99,9 @@
     {
         "name": "Helicopter",
         "movementType": "Land",
-        "uniques": ["Can pass through impassable tiles"]
+        "uniques": ["Can pass through impassable tiles",
+			"[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
+			"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
     },
 
     // Deprecated unit types required for mods without a UnitTypes.json file to work

--- a/jsons/UnitTypes.json
+++ b/jsons/UnitTypes.json
@@ -57,15 +57,11 @@
     },
     {
         "name": "Melee Water",
-        "movementType": "Water",
-		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
-					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
+        "movementType": "Water"
     },
     {
         "name": "Ranged Water",
-        "movementType": "Water",
-		"uniques": ["[Target Unit] gains the [Deflect Active] status for [1] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>",
-					"[Target Unit] gains the [Deflect Cooldown] status for [5] turn(s) <upon damaging a [{non-[Deflect CD]} {Deflect}] unit> <for [Ranged] units>"]
+        "movementType": "Water"
     },
     {
         "name": "Submarine",


### PR DESCRIPTION
Added `<for [Ranged] units>` and add the Deflect related unique to all UnitTypes.

This is so that any units that are not in the Ranged in UnitTypes.json but IS Ranged, may also trigger Deflect. Also to deny, if for whatever reason, there will be a Melee unit with Ranged Unit Type.